### PR TITLE
fix branch for main repo

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -40,6 +40,7 @@ jobs:
           grep -rl '{{gh.repo_name}}' . --exclude-dir .git | xargs sed -i 's/{{gh.repo_name}}/'"${{ github.event.repository.name }}"'/g'
           grep -rl '{{gh.org_name}}' . --exclude-dir .git | xargs sed -i 's/{{gh.org_name}}/'"${{ github.repository_owner }}"'/g'
           grep -rl '{{gh.repository}}' . --exclude-dir .git | xargs sed -i 's@{{gh.repository}}@'"${{ github.repository }}"'@g'
+          grep -rl '{{gh.branch}}' . --exclude-dir .git | xargs sed -i 's@{{gh.branch}}@'"main"'@g'
 
       - name: Setup Python3 🐍
         uses: actions/setup-python@v5


### PR DESCRIPTION
Fix gh.branch to main for the parent repo GH pages build. This is required to craft a valid Codespace URL.